### PR TITLE
add .env.example for environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY="your-api-key" # Get your API key from Google AI Studio: https://aistudio.google.com/


### PR DESCRIPTION
Solves issue https://github.com/google-gemini/veo-3-nano-banana-gemini-api-quickstart/issues/18
Summary
This PR adds a .env.example file to document all required environment variables for the project.
It improves onboarding for new contributors and reduces confusion during local setup by providing a clear template they can copy into their own .env file.

Details
Added a new .env.example file in the project root.
Included placeholder environment variables based on what the CLI currently expects.
No functional changes to the codebase—this is strictly a developer-experience improvement.